### PR TITLE
Updated Hyper to version 0.7 and updated for nightlies 1.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["upnp", "ssdp", "simple", "service", "discovery"]
 license = "MIT"
 
 [dependencies]
-hyper = "0.6.0"
+hyper = "0.7.0"
 libc  = "0.1.0"
 log   = "0.3.0"
 time  = "0.1.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,12 @@ branches:
 
 os:
   - MinGW
-  
+
 install:
   - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe'
-  - ps: Start-FileDownload 'http://slproweb.com/download/Win32OpenSSL-1_0_2d.exe'
+  - ps: Start-FileDownload 'https://slproweb.com/download/Win32OpenSSL-1_0_2e.exe'
   - rust-nightly-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Rust"
-  - Win32OpenSSL-1_0_2d.exe /VERYSILENT /NORESTART /DIR="C:\OpenSSL-Win32" /SUPPRESSMSGBOXES
+  - Win32OpenSSL-1_0_2e.exe /VERYSILENT /NORESTART /DIR="C:\OpenSSL-Win32" /SUPPRESSMSGBOXES
   - SET PATH=%PATH%;C:\MinGW\bin
   - SET PATH=%PATH%;C:\Rust\bin
   - SET OPENSSL_INCLUDE_DIR=C:\OpenSSL-Win32\include

--- a/examples/async_notify.rs
+++ b/examples/async_notify.rs
@@ -2,6 +2,7 @@ extern crate ssdp;
 
 use std::io::{self, Read};
 use std::thread;
+use std::time::Duration;
 
 use ssdp::{FieldMap};
 use ssdp::header::{HeaderMut, NT, NTS, USN};
@@ -13,23 +14,23 @@ fn main() {
             println!("Received The Following Message From {}:\n{:?}\n", src, msg);
         }
     });
-    
+
     // Make Sure Thread Has Started
-    thread::sleep_ms(1000);
-    
+    thread::sleep(Duration::new(1, 0));
+
     // Create A Test Message
     let mut message = NotifyMessage::new();
-    
+
     // Set Some Headers
     message.set(NTS::ByeBye);
     message.set(NT(FieldMap::UPnP(b"rootdevice".to_vec())));
     message.set(USN(FieldMap::UUID(b"Hello, This Is Not A UUID!!!".to_vec()), None));
-    
+
     message.multicast().unwrap();
-    
+
     // Wait Until User Is Done Listening For Notify Messages
     println!("Press Enter When You Wish To Exit...\n");
     let input = io::stdin();
-    
+
     input.bytes().next();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(into_cow, ip_addr, lookup_host, reflect_marker)]
+#![feature(into_cow, lookup_host, reflect_marker)]
 
 //! An asynchronous abstraction for discovering devices and services on a network.
 //!

--- a/src/message/notify.rs
+++ b/src/message/notify.rs
@@ -1,6 +1,5 @@
 use std::borrow::{Cow};
 use std::fmt::{Debug};
-use std::net::{IpAddr};
 use std::str::{FromStr};
 
 use hyper::header::{Header, HeaderFormat};
@@ -9,7 +8,7 @@ use error::{SSDPResult, MsgError};
 use header::{HeaderRef, HeaderMut};
 use message::{self, MessageType};
 use message::ssdp::{SSDPMessage};
-use net::{self};
+use net::{self, IpAddr, SocketIp};
 use receiver::{SSDPReceiver, FromRawSSDP};
 
 /// Notify message that can be sent via multicast to devices on the network.
@@ -23,30 +22,30 @@ impl NotifyMessage {
     pub fn new() -> NotifyMessage {
         NotifyMessage{ message: SSDPMessage::new(MessageType::Notify) }
     }
-    
+
     /// Send this notify message to the standard multicast address.
     pub fn multicast(&mut self) -> SSDPResult<()> {
         let mcast_addr = (message::UPNP_MULTICAST_ADDR, message::UPNP_MULTICAST_PORT);
         let mcast_ttl = Some(message::UPNP_MULTICAST_TTL);
-        
+
         let mut connectors = try!(message::all_local_connectors(mcast_ttl));
-        
+
         // Send On All Connectors
         for conn in connectors.iter_mut() {
             try!(self.message.send(conn, &mcast_addr));
         }
-        
+
         Ok(())
     }
 }
-    
+
 impl FromRawSSDP for NotifyMessage {
     fn raw_ssdp(bytes: &[u8]) -> SSDPResult<NotifyMessage> {
         let message = try!(SSDPMessage::raw_ssdp(bytes));
-        
+
         if message.message_type() != MessageType::Notify {
             try!(Err(MsgError::new("SSDP Message Received Is Not A NotifyMessage")))
-        } else { 
+        } else {
             Ok(NotifyMessage{ message: message })
         }
     }
@@ -56,7 +55,7 @@ impl HeaderRef for NotifyMessage {
     fn get<H>(&self) -> Option<&H> where H: Header + HeaderFormat {
         self.message.get::<H>()
     }
-    
+
     fn get_raw(&self, name: &str) -> Option<&[Vec<u8>]> {
         self.message.get_raw(name)
     }
@@ -66,7 +65,7 @@ impl HeaderMut for NotifyMessage {
     fn set<H>(&mut self, value: H) where H: Header + HeaderFormat {
         self.message.set(value)
     }
-    
+
     fn set_raw<K>(&mut self, name: K, value: Vec<Vec<u8>>) where K: Into<Cow<'static, str>> + Debug {
         self.message.set_raw(name, value)
     }
@@ -82,17 +81,17 @@ impl NotifyListener {
         let mut reuse_sockets = try!(message::map_local_ipv4(|&addr| {
             net::bind_reuse((addr, message::UPNP_MULTICAST_PORT))
         }));
-        
+
         let mcast_addr = try!(IpAddr::from_str(message::UPNP_MULTICAST_ADDR)
             .map_err(|_| MsgError::new("Could Not Parse UPNP_MULTICAST_ADDR") ));
-        
+
         // Subscribe To Multicast On All Of Them
         for sock in reuse_sockets.iter_mut() {
-            let iface_addr = try!(sock.local_addr()).ip();
-        
+            let iface_addr = SocketIp::ip(&try!(sock.local_addr()));
+
             try!(net::join_multicast(sock, &iface_addr, &mcast_addr));
         }
-        
+
         Ok(try!(SSDPReceiver::new(reuse_sockets, None)))
     }
 }
@@ -101,27 +100,27 @@ impl NotifyListener {
 mod tests {
     use super::{NotifyMessage};
     use receiver::{FromRawSSDP};
-    
+
     #[test]
     fn positive_notify_message_type() {
         let raw_message = "NOTIFY * HTTP/1.1\r\nHOST: 192.168.1.1\r\n\r\n";
-        
+
         NotifyMessage::raw_ssdp(raw_message.as_bytes()).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_search_message_type() {
         let raw_message = "M-SEARCH * HTTP/1.1\r\nHOST: 192.168.1.1\r\n\r\n";
-        
+
         NotifyMessage::raw_ssdp(raw_message.as_bytes()).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_response_message_type() {
         let raw_message = "HTTP/1.1 200 OK\r\n\r\n";
-        
+
         NotifyMessage::raw_ssdp(raw_message.as_bytes()).unwrap();
     }
 }


### PR DESCRIPTION
This streamlines the library with Hyper 0.7 which means it does not longer cause problems linking to different openssl versions. It also fixes all deprecations in 1.7, more specifically `thread::sleep` and `IpAddr`.