### PR TITLE
fix: Remove use of deprecated trait `IntoCow`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(into_cow, lookup_host, reflect_marker)]
+#![feature(lookup_host, reflect_marker)]
 
 //! An asynchronous abstraction for discovering devices and services on a network.
 //!

--- a/src/message/ssdp.rs
+++ b/src/message/ssdp.rs
@@ -1,4 +1,4 @@
-use std::borrow::{Cow, IntoCow, ToOwned};
+use std::borrow::{Cow, ToOwned};
 use std::fmt::{Debug};
 use std::io::{Write};
 use std::net::{ToSocketAddrs, SocketAddr};
@@ -134,7 +134,7 @@ fn copy_headers(src_headers: &Headers, dst_headers: &mut Headers) {
     // requires a Cow<'static, _> and we only have access to Cow<'a, _>.
     let iter = src_headers.iter();
     for view in iter {
-        dst_headers.set_raw(view.name().to_owned().into_cow(),
+        dst_headers.set_raw(Cow::Owned(view.name().to_owned()),
                             vec![view.value_string().into_bytes()]);
     }
 }


### PR DESCRIPTION
The trait `IntoCow` was deprecated in Rust 1.7.0