### PR TITLE
fix: `failed to lookup address information` error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ license = "MIT/Apache-2.0"
 libc  = "0.1.0"
 log   = "0.3.0"
 time  = "0.1.0"
+ifaces = "0.0.3"
 
 [dependencies.hyper]
 version = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ license = "MIT/Apache-2.0"
 libc  = "0.1.0"
 log   = "0.3.0"
 time  = "0.1.0"
-ifaces = "0.0.3"
+
+[target.'cfg(not(windows))'.dependencies] ifaces = "0.0.3"
 
 [dependencies.hyper]
 version = "0.9.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ extern crate libc;
 #[macro_use]
 extern crate log;
 extern crate time;
+#[cfg(not(windows))]
+extern crate ifaces;
 
 mod error;
 mod field;

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1,7 +1,9 @@
 //! Messaging primitives for discovering devices and services.
 
 use std::io::{self};
-use std::net::{self, SocketAddr, Ipv4Addr};
+#[cfg(windows)]
+use ::std::net;
+use ::std::net::{SocketAddr, Ipv4Addr};
 
 use net::connector::{UdpConnector};
 
@@ -11,6 +13,9 @@ mod ssdp;
 
 pub use message::search::{SearchRequest, SearchResponse};
 pub use message::notify::{NotifyMessage, NotifyListener};
+
+#[cfg(not(windows))]
+use ::ifaces;
 
 /// Multicast Socket Information
 const UPNP_MULTICAST_ADDR: &'static str = "239.255.255.250";
@@ -38,9 +43,10 @@ fn all_local_connectors(multicast_ttl: Option<i32>) -> io::Result<Vec<UdpConnect
 /// Generate a list of some object R constructed from all local Ipv4Addr objects.
 ///
 /// If any of the SocketAddrs fail to resolve, this function will not return an error.
+#[cfg(windows)]
 fn map_local_ipv4<F, R>(mut f: F) -> io::Result<Vec<R>>
     where F: FnMut(&Ipv4Addr) -> io::Result<R> {
-    let host_iter = try!(net::lookup_host("localhost"));
+    let host_iter = try!(net::lookup_host(""));
     let mut obj_list = match host_iter.size_hint() {
         (_, Some(n)) => Vec::with_capacity(n),
         (_, None)    => Vec::new()
@@ -49,6 +55,34 @@ fn map_local_ipv4<F, R>(mut f: F) -> io::Result<Vec<R>>
     for host in host_iter.filter_map(|host| host.ok()) {
         match host {
             SocketAddr::V4(n) => obj_list.push(try!(f(n.ip()))),
+            _ => ()
+        }
+    }
+
+    Ok(obj_list)
+}
+
+/// Generate a list of some object R constructed from all local Ipv4Addr objects.
+///
+/// If any of the SocketAddrs fail to resolve, this function will not return an error.
+#[cfg(not(windows))]
+fn map_local_ipv4<F, R>(mut f: F) -> io::Result<Vec<R>>
+    where F: FnMut(&Ipv4Addr) -> io::Result<R>
+{
+    let iface_iter = try!(ifaces::Interface::get_all()).into_iter();
+
+    let mut obj_list = match iface_iter.size_hint() {
+        (_, Some(n)) => Vec::with_capacity(n),
+        (_, None)    => Vec::new()
+    };
+
+    for iface in iface_iter.filter(|iface| iface.kind == ifaces::Kind::Ipv4) {
+        match iface.addr {
+            Some(SocketAddr::V4(n)) => {
+                if !n.ip().is_loopback() {
+                    obj_list.push(try!(f(n.ip())))
+                }
+            },
             _ => ()
         }
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -40,18 +40,18 @@ fn all_local_connectors(multicast_ttl: Option<i32>) -> io::Result<Vec<UdpConnect
 /// If any of the SocketAddrs fail to resolve, this function will not return an error.
 fn map_local_ipv4<F, R>(mut f: F) -> io::Result<Vec<R>>
     where F: FnMut(&Ipv4Addr) -> io::Result<R> {
-    let host_iter = try!(net::lookup_host(""));
+    let host_iter = try!(net::lookup_host("localhost"));
     let mut obj_list = match host_iter.size_hint() {
         (_, Some(n)) => Vec::with_capacity(n),
         (_, None)    => Vec::new()
     };
-    
+
     for host in host_iter.filter_map(|host| host.ok()) {
         match host {
             SocketAddr::V4(n) => obj_list.push(try!(f(n.ip()))),
             _ => ()
         }
     }
-    
+
     Ok(obj_list)
 }

--- a/src/message/notify.rs
+++ b/src/message/notify.rs
@@ -23,9 +23,14 @@ impl NotifyMessage {
         NotifyMessage{ message: SSDPMessage::new(MessageType::Notify) }
     }
 
-    /// Send this notify message to the standard multicast address.
+    /// Send this notify message to the standard multicast address:port.
     pub fn multicast(&mut self) -> SSDPResult<()> {
-        let mcast_addr = (message::UPNP_MULTICAST_ADDR, message::UPNP_MULTICAST_PORT);
+        self.multicast_with_port(message::UPNP_MULTICAST_PORT)
+    }
+
+    /// Send this notify message to the standard multicast address but a custom port.
+    pub fn multicast_with_port(&mut self, port: u16) -> SSDPResult<()> {
+        let mcast_addr = (message::UPNP_MULTICAST_ADDR, port);
         let mcast_ttl = Some(message::UPNP_MULTICAST_TTL);
 
         let mut connectors = try!(message::all_local_connectors(mcast_ttl));

--- a/src/message/search.rs
+++ b/src/message/search.rs
@@ -50,9 +50,14 @@ impl SearchRequest {
         Ok(try!(SSDPReceiver::new(raw_connectors, opt_timeout)))
     }
 
-    /// Send this search request to the standard multicast address.
+    /// Send this search request to the standard multicast address:port.
     pub fn multicast(&mut self) -> SSDPResult<SSDPReceiver<SearchResponse>> {
-        let mcast_addr = (message::UPNP_MULTICAST_ADDR, message::UPNP_MULTICAST_PORT);
+        self.multicast_with_port(message::UPNP_MULTICAST_PORT)
+    }
+
+    /// Send this search request to the standard multicast address but a custom port
+    pub fn multicast_with_port(&mut self, port: u16) -> SSDPResult<SSDPReceiver<SearchResponse>> {
+        let mcast_addr = (message::UPNP_MULTICAST_ADDR, port);
         let mcast_timeout = try!(multicast_timeout(self.get::<MX>()));
         let mcast_ttl = Some(message::UPNP_MULTICAST_TTL);
 


### PR DESCRIPTION
`::std::net::lookup_host("")` fails with:

**failed to lookup address information: nodename nor servname provided, or not known**

`::std::net::lookup_host("localhost")` returns the local addresses correctly on both OSX and Ubuntu 15.04.