### PR TITLE
feat: Add several missing headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Cargo.lock
 
 # Temporary
 /design/
+
+# IDE - vscode
+.vscode

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+max_width = 110
+ideal_width = 100
+fn_call_width = 100
+format_strings = false

--- a/src/header/bootid.rs
+++ b/src/header/bootid.rs
@@ -9,28 +9,24 @@ const BOOTID_HEADER_NAME: &'static str = "BOOTID.UPNP.ORG";
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct BootID(pub u32);
 
-unsafe impl Sync for BootID { }
-
-unsafe impl Send for BootID { }
-
 impl Header for BootID {
     fn header_name() -> &'static str {
         BOOTID_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         let cow_str = String::from_utf8_lossy(&raw[0][..]);
-        
+
         // Value needs to be a 31 bit non-negative integer, so convert to i32
         let value = match i32::from_str_radix(&*cow_str, 10) {
             Ok(n) => n,
-            Err(_) => return Err(Error::Header)
+            Err(_) => return Err(Error::Header),
         };
-        
+
         // Check if value is negative, then convert to u32
         if value.is_negative() {
             Err(Error::Header)
@@ -43,73 +39,73 @@ impl Header for BootID {
 impl HeaderFormat for BootID {
     fn fmt_header(&self, fmt: &mut Formatter) -> Result {
         try!(fmt.write_fmt(format_args!("{}", self.0)));
-        
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use super::{BootID};
-    
+    use hyper::header::Header;
+
+    use super::BootID;
+
     #[test]
     fn positive_bootid() {
         let bootid_header_value = &[b"1216907400"[..].to_vec()];
-        
+
         BootID::parse_header(bootid_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_leading_zeros() {
         let bootid_header_value = &[b"0000001216907400"[..].to_vec()];
-        
+
         BootID::parse_header(bootid_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_lower_bound() {
         let bootid_header_value = &[b"0"[..].to_vec()];
-        
+
         BootID::parse_header(bootid_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_upper_bound() {
         let bootid_header_value = &[b"2147483647"[..].to_vec()];
-        
+
         BootID::parse_header(bootid_header_value).unwrap();
     }
-       
+
     #[test]
     fn positive_negative_zero() {
         let bootid_header_value = &[b"-0"[..].to_vec()];
-        
+
         BootID::parse_header(bootid_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_overflow() {
         let bootid_header_value = &[b"2290649224"[..].to_vec()];
-        
+
         BootID::parse_header(bootid_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_negative_overflow() {
         let bootid_header_value = &[b"-2290649224"[..].to_vec()];
-        
+
         BootID::parse_header(bootid_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_nan() {
         let bootid_header_value = &[b"2290wow649224"[..].to_vec()];
-        
+
         BootID::parse_header(bootid_header_value).unwrap();
     }
 }

--- a/src/header/configid.rs
+++ b/src/header/configid.rs
@@ -9,33 +9,29 @@ const CONFIGID_HEADER_NAME: &'static str = "CONFIGID.UPNP.ORG";
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct ConfigID(pub u32);
 
-unsafe impl Sync for ConfigID { }
-
-unsafe impl Send for ConfigID { }
-
 impl Header for ConfigID {
     fn header_name() -> &'static str {
         CONFIGID_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         let cow_str = String::from_utf8_lossy(&raw[0][..]);
-        
+
         // Value needs to be a 31 bit non-negative integer, so convert to i32
         let value = match i32::from_str_radix(&*cow_str, 10) {
             Ok(n) => n,
-            Err(_) => return Err(Error::Header)
+            Err(_) => return Err(Error::Header),
         };
-        
+
         // UPnP 1.1 spec says higher numbers are reserved for future use by the
         // technical committee. Devices should use numbers in the range 0 to
         // 16777215 (2^24-1) but I am not sure where the reserved numbers will
         // appear so we will ignore checking that the range is satisfied here.
-        
+
         // Check if value is negative, then convert to u32
         if value.is_negative() {
             Err(Error::Header)
@@ -48,73 +44,73 @@ impl Header for ConfigID {
 impl HeaderFormat for ConfigID {
     fn fmt_header(&self, fmt: &mut Formatter) -> Result {
         try!(fmt.write_fmt(format_args!("{}", self.0)));
-        
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use super::{ConfigID};
-    
+    use hyper::header::Header;
+
+    use super::ConfigID;
+
     #[test]
     fn positive_configid() {
         let configid_header_value = &[b"1777215"[..].to_vec()];
-        
+
         ConfigID::parse_header(configid_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_reserved() {
         let configid_header_value = &[b"20720000"[..].to_vec()];
-        
+
         ConfigID::parse_header(configid_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_lower_bound() {
         let configid_header_value = &[b"0"[..].to_vec()];
-        
+
         ConfigID::parse_header(configid_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_upper_bound() {
         let configid_header_value = &[b"2147483647"[..].to_vec()];
-        
+
         ConfigID::parse_header(configid_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_negative_zero() {
         let configid_header_value = &[b"-0"[..].to_vec()];
-        
+
         ConfigID::parse_header(configid_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_overflow() {
         let configid_header_value = &[b"2290649224"[..].to_vec()];
-        
+
         ConfigID::parse_header(configid_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_negative_overflow() {
         let configid_header_value = &[b"-2290649224"[..].to_vec()];
-        
+
         ConfigID::parse_header(configid_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_nan() {
         let configid_header_value = &[b"2290wow649224"[..].to_vec()];
-        
+
         ConfigID::parse_header(configid_header_value).unwrap();
     }
 }

--- a/src/header/man.rs
+++ b/src/header/man.rs
@@ -3,31 +3,27 @@ use std::fmt::{Formatter, Result};
 use hyper::error::{self, Error};
 use hyper::header::{HeaderFormat, Header};
 
-const MAN_HEADER_NAME:  &'static str = "MAN";
+const MAN_HEADER_NAME: &'static str = "MAN";
 const MAN_HEADER_VALUE: &'static str = "\"ssdp:discover\"";
 
 /// Represents a header used to specify HTTP extension.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Man;
 
-unsafe impl Sync for Man { }
-
-unsafe impl Send for Man { }
-
 impl Header for Man {
     fn header_name() -> &'static str {
         MAN_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         let man_bytes = MAN_HEADER_VALUE.as_bytes();
         match &raw[0][..] {
             n if n == man_bytes => Ok(Man),
-            _ => Err(Error::Header)
+            _ => Err(Error::Header),
         }
     }
 }
@@ -35,37 +31,37 @@ impl Header for Man {
 impl HeaderFormat for Man {
     fn fmt_header(&self, fmt: &mut Formatter) -> Result {
         try!(fmt.write_str(MAN_HEADER_VALUE));
-        
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use super::{Man};
-    
+    use hyper::header::Header;
+
+    use super::Man;
+
     #[test]
     fn positive_man() {
         let man_header = &[b"\"ssdp:discover\""[..].to_vec()];
-        
+
         Man::parse_header(man_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_wrong_case() {
         let wrong_case_man_header = &[b"\"SSDP:discover\""[..].to_vec()];
-        
+
         Man::parse_header(wrong_case_man_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_missing_quotes() {
         let missing_quotes_man_header = &[b"ssdp:discover"[..].to_vec()];
-        
+
         Man::parse_header(missing_quotes_man_header).unwrap();
     }
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -31,6 +31,9 @@ pub use self::securelocation::SecureLocation;
 pub use self::st::ST;
 pub use self::usn::USN;
 
+// Re-exports
+pub use hyper::header::{Location, Server, CacheControl, CacheDirective};
+
 /// Trait for viewing the contents of a header structure.
 pub trait HeaderRef: Debug {
     /// View a reference to a header field if it exists.

--- a/src/header/mx.rs
+++ b/src/header/mx.rs
@@ -27,33 +27,28 @@ pub struct MX(pub u8);
 impl MX {
     pub fn new(wait_bound: u8) -> SSDPResult<MX> {
         if wait_bound < MX_HEADER_MIN || wait_bound > MX_HEADER_MAX {
-            Err(SSDPError::InvalidHeader(MX_HEADER_NAME, 
-                                         "Supplied Wait Bound Is Out Of Bounds"))
+            Err(SSDPError::InvalidHeader(MX_HEADER_NAME, "Supplied Wait Bound Is Out Of Bounds"))
         } else {
             Ok(MX(wait_bound))
         }
     }
 }
 
-unsafe impl Sync for MX { }
-
-unsafe impl Send for MX { }
-
 impl Header for MX {
     fn header_name() -> &'static str {
         MX_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         let cow_string = String::from_utf8_lossy(&raw[0][..]);
-    
+
         match u8::from_str_radix(&cow_string, 10) {
             Ok(n) if n >= MX_HEADER_MIN && n <= MX_HEADER_MAX => Ok(MX(n)),
-            _ => Err(Error::Header)
+            _ => Err(Error::Header),
         }
     }
 }
@@ -61,76 +56,76 @@ impl Header for MX {
 impl HeaderFormat for MX {
     fn fmt_header(&self, fmt: &mut Formatter) -> Result {
         try!(fmt.write_fmt(format_args!("{}", self.0)));
-        
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use super::{MX};
-    
+    use hyper::header::Header;
+
+    use super::MX;
+
     #[test]
     fn positive_lower_bound() {
         let mx_lower_header = &[b"1"[..].to_vec()];
-        
+
         match MX::parse_header(mx_lower_header) {
             Ok(n) if n == MX(1) => (),
-            _ => panic!("Failed To Accept 1 As MX Value")
+            _ => panic!("Failed To Accept 1 As MX Value"),
         };
     }
-    
+
     #[test]
     fn positive_inner_bound() {
         let mx_inner_header = &[b"5"[..].to_vec()];
-        
+
         match MX::parse_header(mx_inner_header) {
             Ok(n) if n == MX(5) => (),
-            _ => panic!("Failed To Accept 5 As MX Value")
+            _ => panic!("Failed To Accept 5 As MX Value"),
         };
     }
-    
+
     #[test]
     fn positive_upper_bound() {
         let mx_upper_header = &[b"120"[..].to_vec()];
-        
+
         match MX::parse_header(mx_upper_header) {
             Ok(n) if n == MX(120) => (),
-            _ => panic!("Failed To Accept 120 As MX Value")
+            _ => panic!("Failed To Accept 120 As MX Value"),
         };
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_decimal_bound() {
         let mx_decimal_header = &[b"0.5"[..].to_vec()];
-        
+
         MX::parse_header(mx_decimal_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_negative_bound() {
         let mx_negative_header = &[b"-5"[..].to_vec()];
-        
+
         MX::parse_header(mx_negative_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_too_high_bound() {
         let mx_too_high_header = &[b"121"[..].to_vec()];
-        
+
         MX::parse_header(mx_too_high_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_zero_bound() {
         let mx_zero_header = &[b"0"[..].to_vec()];
-        
+
         MX::parse_header(mx_zero_header).unwrap();
     }
 }

--- a/src/header/nt.rs
+++ b/src/header/nt.rs
@@ -3,7 +3,7 @@ use std::fmt::{Formatter, Display, Result};
 use hyper::error::{self, Error};
 use hyper::header::{HeaderFormat, Header};
 
-use {FieldMap};
+use FieldMap;
 
 const NT_HEADER_NAME: &'static str = "NT";
 
@@ -19,23 +19,19 @@ impl NT {
     }
 }
 
-unsafe impl Sync for NT { }
-
-unsafe impl Send for NT { }
-
 impl Header for NT {
     fn header_name() -> &'static str {
         NT_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         match FieldMap::new(&raw[0][..]) {
             Some(n) => Ok(NT(n)),
-            None    => Err(Error::Header)
+            None => Err(Error::Header),
         }
     }
 }
@@ -43,16 +39,16 @@ impl Header for NT {
 impl HeaderFormat for NT {
     fn fmt_header(&self, fmt: &mut Formatter) -> Result {
         try!(Display::fmt(&self.0, fmt));
-        
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use super::{NT};
+    use hyper::header::Header;
+
+    use super::NT;
     use FieldMap::{UPnP, UUID, URN, Unknown};
 
     #[test]
@@ -61,111 +57,113 @@ mod tests {
 
         let data = match NT::parse_header(uuid_header) {
             Ok(NT(UUID(n))) => n,
-            _                 => panic!("uuid Token Not Parsed")
+            _ => panic!("uuid Token Not Parsed"),
         };
-        
-        assert!(uuid_header[0][5..].iter().zip(data.iter()).all(|(a,b)| a == b));
+
+        assert!(uuid_header[0][5..].iter().zip(data.iter()).all(|(a, b)| a == b));
     }
-    
+
     #[test]
     fn positive_upnp() {
         let upnp_header = &["upnp:rootdevice".to_string().into_bytes()];
-            
+
         let data = match NT::parse_header(upnp_header) {
             Ok(NT(UPnP(n))) => n,
-            _                 => panic!("upnp Token Not Parsed")
+            _ => panic!("upnp Token Not Parsed"),
         };
-        
-        assert!(upnp_header[0][5..].iter().zip(data.iter()).all(|(a,b)| a == b));
+
+        assert!(upnp_header[0][5..].iter().zip(data.iter()).all(|(a, b)| a == b));
     }
-    
+
     #[test]
     fn positive_urn() {
         let urn_header = &["urn:schemas-upnp-org:device:printer:1".to_string().into_bytes()];
-            
+
         let data = match NT::parse_header(urn_header) {
             Ok(NT(URN(n))) => n,
-            _                => panic!("urn Token Not Parsed")
+            _ => panic!("urn Token Not Parsed"),
         };
-        
-        assert!(urn_header[0][4..].iter().zip(data.iter()).all(|(a,b)| a == b));
+
+        assert!(urn_header[0][4..].iter().zip(data.iter()).all(|(a, b)| a == b));
     }
-    
+
     #[test]
     fn positive_unknown() {
         let unknown_header = &["max-age:1500::upnp:rootdevice".to_string().into_bytes()];
-            
+
         let (k, v) = match NT::parse_header(unknown_header) {
             Ok(NT(Unknown(k, v))) => (k, v),
-            _                       => panic!("Unknown Token Not Parsed")
+            _ => panic!("Unknown Token Not Parsed"),
         };
-        
+
         let sep_iter = b":".iter();
         let mut original_iter = unknown_header[0][..].iter();
         let mut result_iter = k[..].iter().chain(sep_iter).chain(v[..].iter());
-        
-        assert!(original_iter.by_ref().zip(result_iter.by_ref()).all(|(&a,&b)| a == b));
+
+        assert!(original_iter.by_ref().zip(result_iter.by_ref()).all(|(&a, &b)| a == b));
         assert!(result_iter.next().is_none() && original_iter.next().is_none());
     }
-    
+
     #[test]
     fn positive_short_field() {
         let short_header = &["a:a".to_string().into_bytes()];
-        
+
         let (k, v) = match NT::parse_header(short_header) {
             Ok(NT(Unknown(k, v))) => (k, v),
-            _                       => panic!("Unknown Short Token Not Parsed")
+            _ => panic!("Unknown Short Token Not Parsed"),
         };
-        
+
         let sep_iter = b":".iter();
         let mut original_iter = short_header[0][..].iter();
         let mut result_iter = k[..].iter().chain(sep_iter).chain(v[..].iter());
-        
-        assert!(original_iter.by_ref().zip(result_iter.by_ref()).all(|(&a,&b)| a == b));
+
+        assert!(original_iter.by_ref().zip(result_iter.by_ref()).all(|(&a, &b)| a == b));
         assert!(result_iter.next().is_none() && original_iter.next().is_none());
     }
-    
+
     #[test]
     fn positive_leading_double_colon() {
-        let leading_double_colon_header = &["uuid::a984bc8c-aaf0-5dff-b980-00d098bda247".to_string().into_bytes()];
-        
+        let leading_double_colon_header = &["uuid::a984bc8c-aaf0-5dff-b980-00d098bda247"
+                                                .to_string()
+                                                .into_bytes()];
+
         let result = match NT::parse_header(leading_double_colon_header).unwrap() {
             NT(UUID(n)) => n,
-            _           => panic!("NT Double Colon Failed To Parse")
+            _ => panic!("NT Double Colon Failed To Parse"),
         };
-        
+
         assert_eq!(result, b":a984bc8c-aaf0-5dff-b980-00d098bda247".to_vec());
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_double_colon() {
         let double_colon_header = &["::".to_string().into_bytes()];
-        
+
         NT::parse_header(double_colon_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_single_colon() {
         let single_colon_header = &[":".to_string().into_bytes()];
-        
+
         NT::parse_header(single_colon_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_empty_field() {
         let empty_header = &["".to_string().into_bytes()];
-        
+
         NT::parse_header(empty_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_no_colon() {
         let no_colon_header = &["some_key-some_value".to_string().into_bytes()];
-        
+
         NT::parse_header(no_colon_header).unwrap();
     }
 }

--- a/src/header/nts.rs
+++ b/src/header/nts.rs
@@ -5,7 +5,7 @@ use hyper::header::{HeaderFormat, Header};
 
 const NTS_HEADER_NAME: &'static str = "NTS";
 
-const ALIVE_HEADER:  &'static str = "ssdp:alive";
+const ALIVE_HEADER: &'static str = "ssdp:alive";
 const UPDATE_HEADER: &'static str = "ssdp:update";
 const BYEBYE_HEADER: &'static str = "ssdp:byebye";
 
@@ -20,23 +20,19 @@ pub enum NTS {
     /// enabled interface is added to an already existing UPnP device on a network.
     Update,
     /// An entity is removing itself from the network.
-    ByeBye
+    ByeBye,
 }
-
-unsafe impl Sync for NTS { }
-
-unsafe impl Send for NTS { }
 
 impl Header for NTS {
     fn header_name() -> &'static str {
         NTS_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         if &raw[0][..] == ALIVE_HEADER.as_bytes() {
             Ok(NTS::Alive)
         } else if &raw[0][..] == UPDATE_HEADER.as_bytes() {
@@ -54,78 +50,78 @@ impl HeaderFormat for NTS {
         match *self {
             NTS::Alive => try!(fmt.write_str(ALIVE_HEADER)),
             NTS::Update => try!(fmt.write_str(UPDATE_HEADER)),
-            NTS::ByeBye => try!(fmt.write_str(BYEBYE_HEADER))
+            NTS::ByeBye => try!(fmt.write_str(BYEBYE_HEADER)),
         };
-    
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use super::{NTS};
-    
+    use hyper::header::Header;
+
+    use super::NTS;
+
     #[test]
     fn positive_alive() {
         let alive_header = &[b"ssdp:alive"[..].to_vec()];
-        
+
         match NTS::parse_header(alive_header) {
             Ok(NTS::Alive) => (),
-            _                => panic!("Didn't Match With NTS::Alive")
+            _ => panic!("Didn't Match With NTS::Alive"),
         };
     }
-    
+
     #[test]
     fn positive_update() {
         let update_header = &[b"ssdp:update"[..].to_vec()];
-        
+
         match NTS::parse_header(update_header) {
             Ok(NTS::Update) => (),
-            _                => panic!("Didn't Match With NTS::Update")
+            _ => panic!("Didn't Match With NTS::Update"),
         };
     }
-    
+
     #[test]
     fn positive_byebye() {
         let byebye_header = &[b"ssdp:byebye"[..].to_vec()];
-        
+
         match NTS::parse_header(byebye_header) {
             Ok(NTS::ByeBye) => (),
-            _                => panic!("Didn't Match With NTS::ByeBye")
+            _ => panic!("Didn't Match With NTS::ByeBye"),
         };
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_alive_extra() {
         let alive_extra_header = &[b"ssdp:alive_someotherbytes"[..].to_vec()];
-        
+
         NTS::parse_header(alive_extra_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_unknown() {
         let unknown_header = &[b"ssdp:somestring"[..].to_vec()];
-        
+
         NTS::parse_header(unknown_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_empty() {
         let empty_header = &[b""[..].to_vec()];
-        
+
         NTS::parse_header(empty_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_no_value() {
         let no_value_header = &[b"ssdp:"[..].to_vec()];
-        
+
         NTS::parse_header(no_value_header).unwrap();
     }
 }

--- a/src/header/searchport.rs
+++ b/src/header/searchport.rs
@@ -15,27 +15,23 @@ pub const SEARCHPORT_MAX_VALUE: u16 = 65535;
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct SearchPort(pub u16);
 
-unsafe impl Sync for SearchPort { }
-
-unsafe impl Send for SearchPort { }
-
 impl Header for SearchPort {
     fn header_name() -> &'static str {
         SEARCHPORT_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         let cow_str = String::from_utf8_lossy(&raw[0][..]);
-        
+
         let value = match u16::from_str_radix(&*cow_str, 10) {
             Ok(n) => n,
-            Err(_) => return Err(Error::Header)
+            Err(_) => return Err(Error::Header),
         };
-        
+
         if value <= SEARCHPORT_MAX_VALUE && value >= SEARCHPORT_MIN_VALUE {
             Ok(SearchPort(value))
         } else {
@@ -47,51 +43,51 @@ impl Header for SearchPort {
 impl HeaderFormat for SearchPort {
     fn fmt_header(&self, fmt: &mut Formatter) -> Result {
         try!(fmt.write_fmt(format_args!("{}", self.0)));
-        
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use super::{SearchPort};
-    
+    use hyper::header::Header;
+
+    use super::SearchPort;
+
     #[test]
     fn positive_searchport() {
         let searchport_header_value = &[b"50000"[..].to_vec()];
-        
+
         SearchPort::parse_header(searchport_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_lower_bound() {
         let searchport_header_value = &[b"49152"[..].to_vec()];
-        
+
         SearchPort::parse_header(searchport_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_upper_bound() {
         let searchport_header_value = &[b"65535"[..].to_vec()];
-        
+
         SearchPort::parse_header(searchport_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_reserved() {
         let searchport_header_value = &[b"49151"[..].to_vec()];
-        
+
         SearchPort::parse_header(searchport_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_nan() {
         let searchport_header_value = &[b"49151a"[..].to_vec()];
-        
+
         SearchPort::parse_header(searchport_header_value).unwrap();
     }
 }

--- a/src/header/securelocation.rs
+++ b/src/header/securelocation.rs
@@ -11,25 +11,21 @@ const SECURELOCATION_HEADER_NAME: &'static str = "SECURELOCATION.UPNP.ORG";
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct SecureLocation(pub String);
 
-unsafe impl Sync for SecureLocation { }
-
-unsafe impl Send for SecureLocation { }
-
 impl Header for SecureLocation {
     fn header_name() -> &'static str {
         SECURELOCATION_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 || raw[0].is_empty() {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         let owned_bytes = raw[0].clone();
-        
+
         match String::from_utf8(owned_bytes) {
-            Ok(n)  => Ok(SecureLocation(n)),
-            Err(_) => Err(Error::Header)
+            Ok(n) => Ok(SecureLocation(n)),
+            Err(_) => Err(Error::Header),
         }
     }
 }
@@ -37,44 +33,44 @@ impl Header for SecureLocation {
 impl HeaderFormat for SecureLocation {
     fn fmt_header(&self, fmt: &mut Formatter) -> Result {
         try!(fmt.write_str(&self.0));
-        
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use super::{SecureLocation};
-    
+    use hyper::header::Header;
+
+    use super::SecureLocation;
+
     #[test]
     fn positive_securelocation() {
         let securelocation_header_value = &[b"https://192.168.1.1/"[..].to_vec()];
-        
+
         SecureLocation::parse_header(securelocation_header_value).unwrap();
     }
-    
+
     #[test]
     fn positive_invalid_url() {
         let securelocation_header_value = &[b"just some text"[..].to_vec()];
-        
+
         SecureLocation::parse_header(securelocation_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_empty() {
         let securelocation_header_value = &[b""[..].to_vec()];
-        
+
         SecureLocation::parse_header(securelocation_header_value).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_invalid_utf8() {
         let securelocation_header_value = &[b"https://192.168.1.1/\x80"[..].to_vec()];
-        
+
         SecureLocation::parse_header(securelocation_header_value).unwrap();
     }
 }

--- a/src/header/securelocation.rs
+++ b/src/header/securelocation.rs
@@ -7,7 +7,7 @@ const SECURELOCATION_HEADER_NAME: &'static str = "SECURELOCATION.UPNP.ORG";
 
 /// Represents a header used to specify a secure url for a device's DDD.
 ///
-/// Can be used instead of the Location header field.
+/// Can be used instead of the `Location` header field.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct SecureLocation(pub String);
 

--- a/src/header/st.rs
+++ b/src/header/st.rs
@@ -3,7 +3,7 @@ use std::fmt::{Formatter, Display, Result};
 use hyper::error::{self, Error};
 use hyper::header::{HeaderFormat, Header};
 
-use {FieldMap};
+use FieldMap;
 
 const ST_HEADER_NAME: &'static str = "ST";
 
@@ -13,27 +13,23 @@ const ST_ALL_VALUE: &'static str = "ssdp:all";
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum ST {
     All,
-    Target(FieldMap)
+    Target(FieldMap),
 }
-
-unsafe impl Sync for ST { }
-
-unsafe impl Send for ST { }
 
 impl Header for ST {
     fn header_name() -> &'static str {
         ST_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         if &raw[0][..] == ST_ALL_VALUE.as_bytes() {
             Ok(ST::All)
         } else {
-            FieldMap::new(&raw[0][..]).map( |x| ST::Target(x) ).ok_or(Error::Header)
+            FieldMap::new(&raw[0][..]).map(|x| ST::Target(x)).ok_or(Error::Header)
         }
     }
 }
@@ -41,67 +37,66 @@ impl Header for ST {
 impl HeaderFormat for ST {
     fn fmt_header(&self, fmt: &mut Formatter) -> Result {
         match *self {
-            ST::All           => try!(fmt.write_str(ST_ALL_VALUE)),
-            ST::Target(ref n) => try!(Display::fmt(n, fmt))
+            ST::All => try!(fmt.write_str(ST_ALL_VALUE)),
+            ST::Target(ref n) => try!(Display::fmt(n, fmt)),
         };
-        
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use {FieldMap};
-    use super::{ST};
-    
+    use hyper::header::Header;
+
+    use FieldMap;
+    use super::ST;
+
     #[test]
     fn positive_all() {
         let st_all_header = &[b"ssdp:all"[..].to_vec()];
-    
+
         match ST::parse_header(st_all_header) {
             Ok(ST::All) => (),
-            _ => panic!("Failed To Match ST::All Header")
+            _ => panic!("Failed To Match ST::All Header"),
         }
     }
-    
+
     #[test]
     fn positive_field_upnp() {
         let st_upnp_root_header = &[b"upnp:some_identifier"[..].to_vec()];
-    
+
         match ST::parse_header(st_upnp_root_header) {
             Ok(ST::Target(FieldMap::UPnP(_))) => (),
-            _ => panic!("Failed To Match ST::Target Header To FieldMap::UPnP")
+            _ => panic!("Failed To Match ST::Target Header To FieldMap::UPnP"),
         }
     }
-    
+
     #[test]
     fn positive_field_urn() {
         let st_urn_root_header = &[b"urn:some_identifier"[..].to_vec()];
-    
+
         match ST::parse_header(st_urn_root_header) {
             Ok(ST::Target(FieldMap::URN(_))) => (),
-            _ => panic!("Failed To Match ST::Target Header To FieldMap::URN")
+            _ => panic!("Failed To Match ST::Target Header To FieldMap::URN"),
         }
     }
-    
+
     #[test]
     fn positive_field_uuid() {
         let st_uuid_root_header = &[b"uuid:some_identifier"[..].to_vec()];
-    
+
         match ST::parse_header(st_uuid_root_header) {
             Ok(ST::Target(FieldMap::UUID(_))) => (),
-            _ => panic!("Failed To Match ST::Target Header To FieldMap::UUID")
+            _ => panic!("Failed To Match ST::Target Header To FieldMap::UUID"),
         }
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_multiple_headers() {
-        let st_multiple_headers = &[b"uuid:some_identifier"[..].to_vec(), 
-            b"ssdp:all"[..].to_vec()];
-    
+        let st_multiple_headers = &[b"uuid:some_identifier"[..].to_vec(), b"ssdp:all"[..].to_vec()];
+
         ST::parse_header(st_multiple_headers).unwrap();
     }
 }

--- a/src/header/usn.rs
+++ b/src/header/usn.rs
@@ -3,7 +3,7 @@ use std::fmt::{Formatter, Display, Result};
 use hyper::error::{self, Error};
 use hyper::header::{HeaderFormat, Header};
 
-use {FieldMap};
+use FieldMap;
 use field;
 
 const USN_HEADER_NAME: &'static str = "USN";
@@ -23,29 +23,25 @@ impl USN {
     }
 }
 
-unsafe impl Sync for USN { }
-
-unsafe impl Send for USN { }
-
 impl Header for USN {
     fn header_name() -> &'static str {
         USN_HEADER_NAME
     }
-    
+
     fn parse_header(raw: &[Vec<u8>]) -> error::Result<Self> {
         if raw.len() != 1 {
-            return Err(Error::Header)
+            return Err(Error::Header);
         }
-        
+
         let (first, second) = match partition_pairs(raw[0][..].iter()) {
             Some((n, Some(u))) => (FieldMap::new(&n[..]), FieldMap::new(&u[..])),
-            Some((n, None))    => (FieldMap::new(&n[..]), None),
-            None               => return Err(Error::Header)
+            Some((n, None)) => (FieldMap::new(&n[..]), None),
+            None => return Err(Error::Header),
         };
 
         match first {
             Some(n) => Ok(USN(n, second)),
-            None    => Err(Error::Header)
+            None => Err(Error::Header),
         }
     }
 }
@@ -53,29 +49,30 @@ impl Header for USN {
 impl HeaderFormat for USN {
     fn fmt_header(&self, fmt: &mut Formatter) -> Result {
         try!(Display::fmt(&self.0, fmt));
-        
+
         match self.1 {
             Some(ref n) => {
                 try!(fmt.write_fmt(format_args!("{}", FIELD_PAIR_SEPARATOR)));
                 try!(Display::fmt(n, fmt));
             }
-            None => ()
+            None => (),
         }
-        
+
         Ok(())
     }
 }
 
 fn partition_pairs<'a, I>(header_iter: I) -> Option<(Vec<u8>, Option<Vec<u8>>)>
-    where I: Iterator<Item=&'a u8> {
+    where I: Iterator<Item = &'a u8>
+{
     let mut second_partition = false;
     let mut header_iter = header_iter.peekable();
-    
+
     let mut last_byte = match header_iter.peek() {
         Some(&&n) => n,
-        None      => return None
+        None => return None,
     };
-    
+
     // Seprate field into two vecs, store separators on end of first
     let (mut first, second): (Vec<u8>, Vec<u8>) = header_iter.map(|&n| n).partition(|&n| {
         if second_partition {
@@ -83,11 +80,11 @@ fn partition_pairs<'a, I>(header_iter: I) -> Option<(Vec<u8>, Option<Vec<u8>>)>
         } else {
             second_partition = [last_byte, n] == FIELD_PAIR_SEPARATOR.as_bytes();
             last_byte = n;
-            
+
             true
         }
     });
-    
+
     // Remove up to two separators from end of first
     for _ in 0..2 {
         match first[..].last() {
@@ -95,80 +92,80 @@ fn partition_pairs<'a, I>(header_iter: I) -> Option<(Vec<u8>, Option<Vec<u8>>)>
                 if n == field::PAIR_SEPARATOR as u8 {
                     first.pop();
                 }
-            },
-            _ => ()
+            }
+            _ => (),
         };
     }
-    
+
     match (first.is_empty(), second.is_empty()) {
         (false, false) => Some((first, Some(second))),
-        (false, true)  => Some((first, None)),
-        _              => None
+        (false, true) => Some((first, None)),
+        _ => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use hyper::header::{Header};
-    
-    use super::{USN};
+    use hyper::header::Header;
+
+    use super::USN;
     use FieldMap::{UPnP, UUID, URN, Unknown};
-    
+
     #[test]
     fn positive_double_pair() {
         let double_pair_header = &["uuid:device-UUID::upnp:rootdevice".to_string().into_bytes()];
         let USN(first, second) = USN::parse_header(double_pair_header).unwrap();
-        
+
         match first {
             UUID(n) => assert_eq!(&n[..], &(b"device-UUID")[..]),
-            _       => panic!("Didnt Match uuid")
+            _ => panic!("Didnt Match uuid"),
         };
-        
+
         match second.unwrap() {
             UPnP(n) => assert_eq!(&n[..], &(b"rootdevice")[..]),
-            _       => panic!("Didnt Match upnp")
+            _ => panic!("Didnt Match upnp"),
         };
     }
-    
+
     #[test]
     fn positive_single_pair() {
         let single_pair_header = &["urn:device-URN".to_string().into_bytes()];
         let USN(first, second) = USN::parse_header(single_pair_header).unwrap();
-        
+
         match first {
             URN(n) => assert_eq!(&n[..], &(b"device-URN")[..]),
-            _       => panic!("Didnt Match urn")
+            _ => panic!("Didnt Match urn"),
         };
-        
+
         assert!(second.is_none());
     }
-    
+
     #[test]
     fn positive_trailing_double_colon() {
         let trailing_double_colon_header = &["upnp:device-UPnP::".to_string().into_bytes()];
         let USN(first, second) = USN::parse_header(trailing_double_colon_header).unwrap();
-        
+
         match first {
             UPnP(n) => assert_eq!(&n[..], &(b"device-UPnP")[..]),
-            _       => panic!("Didnt Match upnp")
+            _ => panic!("Didnt Match upnp"),
         };
-        
+
         assert!(second.is_none());
     }
-    
+
     #[test]
     fn positive_trailing_single_colon() {
         let trailing_single_colon_header = &["some-key:device-UPnP:".to_string().into_bytes()];
         let USN(first, second) = USN::parse_header(trailing_single_colon_header).unwrap();
-        
+
         match first {
-            Unknown(k,v) => {
+            Unknown(k, v) => {
                 assert_eq!(&k[..], &(b"some-key")[..]);
                 assert_eq!(&v[..], &(b"device-UPnP")[..]);
-            },
-            _       => panic!("Didnt Match upnp")
+            }
+            _ => panic!("Didnt Match upnp"),
         };
-        
+
         assert!(second.is_none());
     }
 
@@ -176,31 +173,31 @@ mod tests {
     #[should_panic]
     fn negative_empty() {
         let empty_header = &["".to_string().into_bytes()];
-        
+
         USN::parse_header(empty_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_colon() {
         let colon_header = &[":".to_string().into_bytes()];
-        
+
         USN::parse_header(colon_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_double_colon() {
         let double_colon_header = &["::".to_string().into_bytes()];
-        
+
         USN::parse_header(double_colon_header).unwrap();
     }
-    
+
     #[test]
     #[should_panic]
     fn negative_double_colon_value() {
         let double_colon_value_header = &["uuid:::".to_string().into_bytes()];
-        
+
         USN::parse_header(double_colon_value_header).unwrap();
     }
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1,11 +1,11 @@
 //! Messaging primitives for discovering devices and services.
 
-use std::io::{self};
+use std::io;
 #[cfg(windows)]
-use ::std::net;
-use ::std::net::{SocketAddr, Ipv4Addr};
+use std::net;
+use std::net::{SocketAddr, Ipv4Addr};
 
-use net::connector::{UdpConnector};
+use net::connector::UdpConnector;
 
 mod notify;
 mod search;
@@ -15,11 +15,11 @@ pub use message::search::{SearchRequest, SearchResponse};
 pub use message::notify::{NotifyMessage, NotifyListener};
 
 #[cfg(not(windows))]
-use ::ifaces;
+use ifaces;
 
 /// Multicast Socket Information
 const UPNP_MULTICAST_ADDR: &'static str = "239.255.255.250";
-const UPNP_MULTICAST_PORT: u16          = 1900;
+pub const UPNP_MULTICAST_PORT: u16 = 1900;
 
 /// Default TTL For Multicast
 const UPNP_MULTICAST_TTL: i32 = 2;
@@ -32,7 +32,7 @@ pub enum MessageType {
     /// A search message.
     Search,
     /// A response to a search message.
-    Response
+    Response,
 }
 
 /// Generate UdpConnector objects for all local IPv4 interfaces.
@@ -45,17 +45,18 @@ fn all_local_connectors(multicast_ttl: Option<i32>) -> io::Result<Vec<UdpConnect
 /// If any of the SocketAddrs fail to resolve, this function will not return an error.
 #[cfg(windows)]
 fn map_local_ipv4<F, R>(mut f: F) -> io::Result<Vec<R>>
-    where F: FnMut(&Ipv4Addr) -> io::Result<R> {
+    where F: FnMut(&Ipv4Addr) -> io::Result<R>
+{
     let host_iter = try!(net::lookup_host(""));
     let mut obj_list = match host_iter.size_hint() {
         (_, Some(n)) => Vec::with_capacity(n),
-        (_, None)    => Vec::new()
+        (_, None) => Vec::new(),
     };
 
     for host in host_iter.filter_map(|host| host.ok()) {
         match host {
             SocketAddr::V4(n) => obj_list.push(try!(f(n.ip()))),
-            _ => ()
+            _ => (),
         }
     }
 
@@ -73,7 +74,7 @@ fn map_local_ipv4<F, R>(mut f: F) -> io::Result<Vec<R>>
 
     let mut obj_list = match iface_iter.size_hint() {
         (_, Some(n)) => Vec::with_capacity(n),
-        (_, None)    => Vec::new()
+        (_, None) => Vec::new(),
     };
 
     for iface in iface_iter.filter(|iface| iface.kind == ifaces::Kind::Ipv4) {
@@ -82,8 +83,8 @@ fn map_local_ipv4<F, R>(mut f: F) -> io::Result<Vec<R>>
                 if !n.ip().is_loopback() {
                     obj_list.push(try!(f(n.ip())))
                 }
-            },
-            _ => ()
+            }
+            _ => (),
         }
     }
 

--- a/src/message/ssdp.rs
+++ b/src/message/ssdp.rs
@@ -1,26 +1,26 @@
 use std::borrow::{Cow, ToOwned};
-use std::fmt::{Debug};
-use std::io::{Write};
+use std::fmt::Debug;
+use std::io::Write;
 use std::net::{ToSocketAddrs, SocketAddr};
 
-use hyper::{Url};
-use hyper::buffer::{BufReader};
-use hyper::client::request::{Request};
+use hyper::Url;
+use hyper::buffer::BufReader;
+use hyper::client::request::Request;
 use hyper::header::{Headers, Header, HeaderFormat, ContentLength, Host};
-use hyper::http::{RawStatus};
+use hyper::http::RawStatus;
 use hyper::http::h1::{self, Incoming};
-use hyper::method::{Method};
+use hyper::method::Method;
 use hyper::net::{NetworkConnector, NetworkStream};
-use hyper::server::response::{Response};
-use hyper::status::{StatusCode};
-use hyper::uri::{RequestUri};
-use hyper::version::{HttpVersion};
+use hyper::server::response::Response;
+use hyper::status::StatusCode;
+use hyper::uri::RequestUri;
+use hyper::version::HttpVersion;
 
 use {SSDPResult, SSDPError};
 use header::{HeaderRef, HeaderMut};
-use message::{MessageType};
+use message::MessageType;
 use net::{self, SocketIp};
-use receiver::{FromRawSSDP};
+use receiver::FromRawSSDP;
 
 /// Only Valid SearchResponse Code
 const VALID_RESPONSE_CODE: u16 = 200;
@@ -35,14 +35,17 @@ const SEARCH_METHOD: &'static str = "M-SEARCH";
 /// Represents an SSDP method combined with both SSDP and HTTP headers.
 #[derive(Debug, Clone)]
 pub struct SSDPMessage {
-    method:  MessageType,
-    headers: Headers
+    method: MessageType,
+    headers: Headers,
 }
 
 impl SSDPMessage {
     /// Construct a new SSDPMessage.
     pub fn new(message_type: MessageType) -> SSDPMessage {
-        SSDPMessage{ method: message_type, headers: Headers::new() }
+        SSDPMessage {
+            method: message_type,
+            headers: Headers::new(),
+        }
     }
 
     /// Get the type of this message.
@@ -54,16 +57,14 @@ impl SSDPMessage {
     ///
     /// The host header field will be taken care of by the underlying library.
     pub fn send<A: ToSocketAddrs, C, S>(&self, connector: &mut C, dst_addr: A) -> SSDPResult<()>
-        where C: NetworkConnector<Stream=S>, S: Into<Box<NetworkStream + Send>> {
+        where C: NetworkConnector<Stream = S>,
+              S: Into<Box<NetworkStream + Send>>
+    {
         let dst_sock_addr = try!(net::addr_from_trait(dst_addr));
 
         match self.method {
-            MessageType::Notify => {
-                send_request(NOTIFY_METHOD, &self.headers, connector, dst_sock_addr)
-            },
-            MessageType::Search => {
-                send_request(SEARCH_METHOD, &self.headers, connector, dst_sock_addr)
-            },
+            MessageType::Notify => send_request(NOTIFY_METHOD, &self.headers, connector, dst_sock_addr),
+            MessageType::Search => send_request(SEARCH_METHOD, &self.headers, connector, dst_sock_addr),
             MessageType::Response => {
                 let dst_ip_string = SocketIp::ip(&dst_sock_addr).to_string();
                 let dst_port = dst_sock_addr.port();
@@ -78,15 +79,17 @@ impl SSDPMessage {
 
 #[allow(unused)]
 /// Send a request using the connector with the supplied method and headers.
-fn send_request<C, S>(method: &str, headers: &Headers, connector: &mut C, dst_addr: SocketAddr)
-    -> SSDPResult<()> where C: NetworkConnector<Stream=S>, S: Into<Box<NetworkStream + Send>> {
+fn send_request<C, S>(method: &str,
+                      headers: &Headers,
+                      connector: &mut C,
+                      dst_addr: SocketAddr)
+                      -> SSDPResult<()>
+    where C: NetworkConnector<Stream = S>,
+          S: Into<Box<NetworkStream + Send>>
+{
     let url = try!(url_from_addr(dst_addr));
 
-    let mut request = try!(Request::with_connector(
-        Method::Extension(method.to_owned()),
-        url,
-        connector
-    ));
+    let mut request = try!(Request::with_connector(Method::Extension(method.to_owned()), url, connector));
 
     copy_headers(headers, request.headers_mut());
     request.headers_mut().set(ContentLength(0));
@@ -101,7 +104,8 @@ fn send_request<C, S>(method: &str, headers: &Headers, connector: &mut C, dst_ad
 
 /// Send an Ok response on the Writer with the supplied headers.
 fn send_response<W>(headers: &Headers, mut dst_writer: W) -> SSDPResult<()>
-    where W: Write {
+    where W: Write
+{
     let mut temp_headers = Headers::new();
 
     copy_headers(headers, &mut temp_headers);
@@ -119,8 +123,8 @@ fn send_response<W>(headers: &Headers, mut dst_writer: W) -> SSDPResult<()>
 /// Convert the given address to a Url with a base of "udp://".
 fn url_from_addr(addr: SocketAddr) -> SSDPResult<Url> {
     let str_url = BASE_HOST_URL.chars()
-        .chain(addr.to_string()[..].chars())
-        .collect::<String>();
+                               .chain(addr.to_string()[..].chars())
+                               .collect::<String>();
 
     Ok(try!(Url::parse(&str_url[..])))
 }
@@ -134,13 +138,14 @@ fn copy_headers(src_headers: &Headers, dst_headers: &mut Headers) {
     // requires a Cow<'static, _> and we only have access to Cow<'a, _>.
     let iter = src_headers.iter();
     for view in iter {
-        dst_headers.set_raw(Cow::Owned(view.name().to_owned()),
-                            vec![view.value_string().into_bytes()]);
+        dst_headers.set_raw(Cow::Owned(view.name().to_owned()), vec![view.value_string().into_bytes()]);
     }
 }
 
 impl HeaderRef for SSDPMessage {
-    fn get<H>(&self) -> Option<&H> where H: Header + HeaderFormat {
+    fn get<H>(&self) -> Option<&H>
+        where H: Header + HeaderFormat
+    {
         HeaderRef::get::<H>(&self.headers)
     }
 
@@ -150,11 +155,15 @@ impl HeaderRef for SSDPMessage {
 }
 
 impl HeaderMut for SSDPMessage {
-    fn set<H>(&mut self, value: H) where H: Header + HeaderFormat {
+    fn set<H>(&mut self, value: H)
+        where H: Header + HeaderFormat
+    {
         HeaderMut::set(&mut self.headers, value)
     }
 
-    fn set_raw<K>(&mut self, name: K, value: Vec<Vec<u8>>) where K: Into<Cow<'static, str>> + Debug {
+    fn set_raw<K>(&mut self, name: K, value: Vec<Vec<u8>>)
+        where K: Into<Cow<'static, str>> + Debug
+    {
         HeaderMut::set_raw(&mut self.headers, name, value)
     }
 }
@@ -184,12 +193,8 @@ impl FromRawSSDP for SSDPMessage {
 /// Logs a debug! message based on the value of the SSDPResult.
 fn log_message_result(result: &SSDPResult<SSDPMessage>, message: &[u8]) {
     match *result {
-        Ok(_) => {
-            debug!("Received Valid SSDPMessage:\n{}", String::from_utf8_lossy(message))
-        },
-        Err(ref e) => {
-            debug!("Received Invalid SSDPMessage Error: {}", e)
-        }
+        Ok(_) => debug!("Received Valid SSDPMessage:\n{}", String::from_utf8_lossy(message)),
+        Err(ref e) => debug!("Received Invalid SSDPMessage Error: {}", e),
     }
 }
 
@@ -203,15 +208,25 @@ fn message_from_request(parts: Incoming<(Method, RequestUri)>) -> SSDPResult<SSD
     match parts.subject {
         (Method::Extension(n), RequestUri::Star) => {
             match &n[..] {
-                NOTIFY_METHOD => Ok(SSDPMessage{ method: MessageType::Notify, headers: headers }),
-                SEARCH_METHOD => Ok(SSDPMessage{ method: MessageType::Search, headers: headers }),
-                _ => Err(SSDPError::InvalidMethod(n))
+                NOTIFY_METHOD => {
+                    Ok(SSDPMessage {
+                        method: MessageType::Notify,
+                        headers: headers,
+                    })
+                }
+                SEARCH_METHOD => {
+                    Ok(SSDPMessage {
+                        method: MessageType::Search,
+                        headers: headers,
+                    })
+                }
+                _ => Err(SSDPError::InvalidMethod(n)),
             }
-        },
-        (n, RequestUri::Star)            => Err(SSDPError::InvalidMethod(n.to_string())),
+        }
+        (n, RequestUri::Star) => Err(SSDPError::InvalidMethod(n.to_string())),
         (_, RequestUri::AbsolutePath(n)) => Err(SSDPError::InvalidUri(n)),
-        (_, RequestUri::Authority(n))    => Err(SSDPError::InvalidUri(n)),
-        (_, RequestUri::AbsoluteUri(n))  => Err(SSDPError::InvalidUri(n.into_string()))
+        (_, RequestUri::Authority(n)) => Err(SSDPError::InvalidUri(n)),
+        (_, RequestUri::AbsoluteUri(n)) => Err(SSDPError::InvalidUri(n.into_string())),
     }
 }
 
@@ -223,52 +238,62 @@ fn message_from_response(parts: Incoming<RawStatus>) -> SSDPResult<SSDPMessage> 
     try!(validate_http_version(parts.version));
     try!(validate_response_code(status_code));
 
-    Ok(SSDPMessage{ method: MessageType::Response, headers: headers })
+    Ok(SSDPMessage {
+        method: MessageType::Response,
+        headers: headers,
+    })
 }
 
 /// Validate the HTTP version for an SSDP message.
 fn validate_http_version(version: HttpVersion) -> SSDPResult<()> {
     if version != HttpVersion::Http11 {
         Err(SSDPError::InvalidHttpVersion)
-    } else { Ok(()) }
+    } else {
+        Ok(())
+    }
 }
 
 /// Validate that the Host header is present.
 fn validate_http_host<T>(headers: T) -> SSDPResult<()>
-    where T: HeaderRef {
+    where T: HeaderRef
+{
     // Shouldn't have to do this but hyper doesn't make sure that HTTP/1.1
     // messages contain Host headers so we will assure conformance ourselves.
     if headers.get::<Host>().is_none() {
         Err(SSDPError::MissingHeader(Host::header_name()))
-    } else { Ok(()) }
+    } else {
+        Ok(())
+    }
 }
 
 /// Validate the response code for an SSDP message.
 fn validate_response_code(code: u16) -> SSDPResult<()> {
     if code != VALID_RESPONSE_CODE {
         Err(SSDPError::ResponseCode(code))
-    } else { Ok(()) }
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod mocks {
-    use std::cell::{RefCell};
+    use std::cell::RefCell;
     use std::io::{self, Read, Write, ErrorKind};
-    use std::marker::{Reflect};
-    use std::net::{SocketAddr};
+    use std::marker::Reflect;
+    use std::net::SocketAddr;
     use std::time::Duration;
     use std::sync::mpsc::{self, Sender, Receiver};
 
-    use hyper::error::{self};
+    use hyper::error;
     use hyper::net::{NetworkConnector, NetworkStream};
 
     pub struct MockConnector {
-        pub receivers: RefCell<Vec<Receiver<Vec<u8>>>>
+        pub receivers: RefCell<Vec<Receiver<Vec<u8>>>>,
     }
 
     impl MockConnector {
         pub fn new() -> MockConnector {
-            MockConnector{ receivers: RefCell::new(Vec::new()) }
+            MockConnector { receivers: RefCell::new(Vec::new()) }
         }
     }
 
@@ -280,12 +305,12 @@ mod mocks {
 
             self.receivers.borrow_mut().push(recv);
 
-            Ok(MockStream{ sender: send })
+            Ok(MockStream { sender: send })
         }
     }
 
     pub struct MockStream {
-        sender: Sender<Vec<u8>>
+        sender: Sender<Vec<u8>>,
     }
 
     impl NetworkStream for MockStream {
@@ -299,10 +324,6 @@ mod mocks {
             Ok(())
         }
     }
-
-    unsafe impl Send for MockStream { }
-
-    impl Reflect for MockStream { }
 
     impl Read for MockStream {
         fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
@@ -330,18 +351,20 @@ mod mocks {
             Ok(buf.len())
         }
 
-        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     mod send {
-        use std::sync::mpsc::{Receiver};
+        use std::sync::mpsc::Receiver;
 
-        use super::super::mocks::{MockConnector};
-        use super::super::{SSDPMessage};
-        use message::{MessageType};
+        use super::super::mocks::MockConnector;
+        use super::super::SSDPMessage;
+        use message::MessageType;
 
         fn join_buffers(recv_list: &[Receiver<Vec<u8>>]) -> Vec<u8> {
             let mut buffer = Vec::new();
@@ -362,9 +385,7 @@ mod tests {
 
             message.send(&mut connector, ("127.0.0.1", 0)).unwrap();
 
-            let sent_message = String::from_utf8(
-                join_buffers(&*connector.receivers.borrow())
-            ).unwrap();
+            let sent_message = String::from_utf8(join_buffers(&*connector.receivers.borrow())).unwrap();
 
             assert_eq!(&sent_message[..19], "M-SEARCH * HTTP/1.1");
         }
@@ -376,9 +397,7 @@ mod tests {
 
             message.send(&mut connector, ("127.0.0.1", 0)).unwrap();
 
-            let sent_message = String::from_utf8(
-                join_buffers(&*connector.receivers.borrow())
-            ).unwrap();
+            let sent_message = String::from_utf8(join_buffers(&*connector.receivers.borrow())).unwrap();
 
             assert_eq!(&sent_message[..17], "NOTIFY * HTTP/1.1");
         }
@@ -390,9 +409,7 @@ mod tests {
 
             message.send(&mut connector, ("127.0.0.1", 0)).unwrap();
 
-            let sent_message = String::from_utf8(
-                join_buffers(&*connector.receivers.borrow())
-            ).unwrap();
+            let sent_message = String::from_utf8(join_buffers(&*connector.receivers.borrow())).unwrap();
 
             assert_eq!(&sent_message[..15], "HTTP/1.1 200 OK");
         }
@@ -404,18 +421,16 @@ mod tests {
 
             message.send(&mut connector, ("127.0.0.1", 0)).unwrap();
 
-            let sent_message = String::from_utf8(
-                join_buffers(&*connector.receivers.borrow())
-            ).unwrap();
+            let sent_message = String::from_utf8(join_buffers(&*connector.receivers.borrow())).unwrap();
 
             assert!(sent_message.contains("Host: 127.0.0.1:0"));
         }
     }
 
     mod parse {
-        use super::super::{SSDPMessage};
-        use header::{HeaderRef};
-        use receiver::{FromRawSSDP};
+        use super::super::SSDPMessage;
+        use header::HeaderRef;
+        use receiver::FromRawSSDP;
 
         #[test]
         fn positive_valid_http() {

--- a/src/net/sender.rs
+++ b/src/net/sender.rs
@@ -1,7 +1,7 @@
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::{UdpSocket, SocketAddr};
 use std::time::Duration;
-use hyper::net::{NetworkStream};
+use hyper::net::NetworkStream;
 
 /// A type that wraps a UdpSocket and a SocketAddr and implements the NetworkStream
 /// trait.
@@ -13,13 +13,17 @@ use hyper::net::{NetworkStream};
 pub struct UdpSender {
     udp: UdpSocket,
     dst: SocketAddr,
-    buf: Vec<u8>
+    buf: Vec<u8>,
 }
 
 impl UdpSender {
     /// Creates a new UdpSender object.
     pub fn new(udp: UdpSocket, dst: SocketAddr) -> UdpSender {
-        UdpSender{ udp: udp, dst: dst, buf: Vec::new() }
+        UdpSender {
+            udp: udp,
+            dst: dst,
+            buf: Vec::new(),
+        }
     }
 }
 
@@ -34,8 +38,6 @@ impl NetworkStream for UdpSender {
         Ok(())
     }
 }
-
-unsafe impl Send for UdpSender { }
 
 impl Read for UdpSender {
     fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
@@ -60,16 +62,16 @@ impl Write for UdpSender {
         }
 
         self.buf.append(&mut buffer);
-        
+
         Ok(buf.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {
         debug!("Sent HTTP Request:\n{}", String::from_utf8_lossy(&self.buf[..]));
-        
+
         let result = self.udp.send_to(&self.buf[..], self.dst);
         self.buf.clear();
-        
+
         result.map(|_| ())
     }
 }
@@ -78,7 +80,11 @@ impl Clone for UdpSender {
     fn clone(&self) -> UdpSender {
         let udp_clone = self.udp.try_clone().unwrap();
 
-        UdpSender{ udp: udp_clone, dst: self.dst, buf: self.buf.clone() }
+        UdpSender {
+            udp: udp_clone,
+            dst: self.dst,
+            buf: self.buf.clone(),
+        }
     }
 
     fn clone_from(&mut self, source: &UdpSender) {


### PR DESCRIPTION
- Re-export **SERVER** from `hyper::header::Server` as `ssdp::header::Server`
- Re-export **LOCATION** `hyper::header::Location` as `ssdp::header::Location`
- Re-export **CACHE-CONTROL** `hyper::header::CacheControl` as `ssdp::header::CacheControl`
- Re-export `hyper::header::CacheDirective` as `ssdp::header::CacheDirective`