### PR TITLE
feat: Make `FieldMap` usage more ergonomic

### DIFF
--- a/examples/async_notify.rs
+++ b/examples/async_notify.rs
@@ -23,8 +23,8 @@ fn main() {
 
     // Set Some Headers
     message.set(NTS::ByeBye);
-    message.set(NT(FieldMap::UPnP(b"rootdevice".to_vec())));
-    message.set(USN(FieldMap::UUID(b"Hello, This Is Not A UUID!!!".to_vec()), None));
+    message.set(NT(FieldMap::upnp("rootdevice")));
+    message.set(USN(FieldMap::uuid("Hello, This Is Not A UUID!!!"), None));
 
     message.multicast().unwrap();
 

--- a/src/header/nt.rs
+++ b/src/header/nt.rs
@@ -29,7 +29,7 @@ impl Header for NT {
             return Err(Error::Header);
         }
 
-        match FieldMap::new(&raw[0][..]) {
+        match FieldMap::parse_bytes(&raw[0][..]) {
             Some(n) => Ok(NT(n)),
             None => Err(Error::Header),
         }
@@ -53,71 +53,71 @@ mod tests {
 
     #[test]
     fn positive_uuid() {
-        let uuid_header = &["uuid:a984bc8c-aaf0-5dff-b980-00d098bda247".to_string().into_bytes()];
+        let header = "uuid:a984bc8c-aaf0-5dff-b980-00d098bda247";
 
-        let data = match NT::parse_header(uuid_header) {
+        let data = match NT::parse_header(&[header.to_string().into_bytes()]) {
             Ok(NT(UUID(n))) => n,
             _ => panic!("uuid Token Not Parsed"),
         };
 
-        assert!(uuid_header[0][5..].iter().zip(data.iter()).all(|(a, b)| a == b));
+        assert!(header.chars().skip(5).zip(data.chars()).all(|(a, b)| a == b));
     }
 
     #[test]
     fn positive_upnp() {
-        let upnp_header = &["upnp:rootdevice".to_string().into_bytes()];
+        let header = "upnp:rootdevice";
 
-        let data = match NT::parse_header(upnp_header) {
+        let data = match NT::parse_header(&[header.to_string().into_bytes()]) {
             Ok(NT(UPnP(n))) => n,
             _ => panic!("upnp Token Not Parsed"),
         };
 
-        assert!(upnp_header[0][5..].iter().zip(data.iter()).all(|(a, b)| a == b));
+        assert!(header.chars().skip(5).zip(data.chars()).all(|(a, b)| a == b));
     }
 
     #[test]
     fn positive_urn() {
-        let urn_header = &["urn:schemas-upnp-org:device:printer:1".to_string().into_bytes()];
+        let header = "urn:schemas-upnp-org:device:printer:1";
 
-        let data = match NT::parse_header(urn_header) {
+        let data = match NT::parse_header(&[header.to_string().into_bytes()]) {
             Ok(NT(URN(n))) => n,
             _ => panic!("urn Token Not Parsed"),
         };
 
-        assert!(urn_header[0][4..].iter().zip(data.iter()).all(|(a, b)| a == b));
+        assert!(header.chars().skip(4).zip(data.chars()).all(|(a, b)| a == b));
     }
 
     #[test]
     fn positive_unknown() {
-        let unknown_header = &["max-age:1500::upnp:rootdevice".to_string().into_bytes()];
+        let header = "max-age:1500::upnp:rootdevice";
 
-        let (k, v) = match NT::parse_header(unknown_header) {
+        let (k, v) = match NT::parse_header(&[header.to_string().into_bytes()]) {
             Ok(NT(Unknown(k, v))) => (k, v),
             _ => panic!("Unknown Token Not Parsed"),
         };
 
-        let sep_iter = b":".iter();
-        let mut original_iter = unknown_header[0][..].iter();
-        let mut result_iter = k[..].iter().chain(sep_iter).chain(v[..].iter());
+        let sep_iter = ":".chars();
+        let mut original_iter = header.chars();
+        let mut result_iter = k.chars().chain(sep_iter).chain(v.chars());
 
-        assert!(original_iter.by_ref().zip(result_iter.by_ref()).all(|(&a, &b)| a == b));
+        assert!(original_iter.by_ref().zip(result_iter.by_ref()).all(|(a, b)| a == b));
         assert!(result_iter.next().is_none() && original_iter.next().is_none());
     }
 
     #[test]
     fn positive_short_field() {
-        let short_header = &["a:a".to_string().into_bytes()];
+        let header = "a:a";
 
-        let (k, v) = match NT::parse_header(short_header) {
+        let (k, v) = match NT::parse_header(&[header.to_string().into_bytes()]) {
             Ok(NT(Unknown(k, v))) => (k, v),
             _ => panic!("Unknown Short Token Not Parsed"),
         };
 
-        let sep_iter = b":".iter();
-        let mut original_iter = short_header[0][..].iter();
-        let mut result_iter = k[..].iter().chain(sep_iter).chain(v[..].iter());
+        let sep_iter = ":".chars();
+        let mut original_iter = header.chars();
+        let mut result_iter = k.chars().chain(sep_iter).chain(v.chars());
 
-        assert!(original_iter.by_ref().zip(result_iter.by_ref()).all(|(&a, &b)| a == b));
+        assert!(original_iter.by_ref().zip(result_iter.by_ref()).all(|(a, b)| a == b));
         assert!(result_iter.next().is_none() && original_iter.next().is_none());
     }
 
@@ -132,7 +132,7 @@ mod tests {
             _ => panic!("NT Double Colon Failed To Parse"),
         };
 
-        assert_eq!(result, b":a984bc8c-aaf0-5dff-b980-00d098bda247".to_vec());
+        assert_eq!(result, ":a984bc8c-aaf0-5dff-b980-00d098bda247");
     }
 
     #[test]

--- a/src/header/st.rs
+++ b/src/header/st.rs
@@ -29,7 +29,7 @@ impl Header for ST {
         if &raw[0][..] == ST_ALL_VALUE.as_bytes() {
             Ok(ST::All)
         } else {
-            FieldMap::new(&raw[0][..]).map(ST::Target).ok_or(Error::Header)
+            FieldMap::parse_bytes(&raw[0][..]).map(ST::Target).ok_or(Error::Header)
         }
     }
 }

--- a/src/header/usn.rs
+++ b/src/header/usn.rs
@@ -34,8 +34,8 @@ impl Header for USN {
         }
 
         let (first, second) = match partition_pairs(raw[0][..].iter()) {
-            Some((n, Some(u))) => (FieldMap::new(&n[..]), FieldMap::new(&u[..])),
-            Some((n, None)) => (FieldMap::new(&n[..]), None),
+            Some((n, Some(u))) => (FieldMap::parse_bytes(&n[..]), FieldMap::parse_bytes(&u[..])),
+            Some((n, None)) => (FieldMap::parse_bytes(&n[..]), None),
             None => return Err(Error::Header),
         };
 
@@ -88,7 +88,7 @@ fn partition_pairs<'a, I>(header_iter: I) -> Option<(Vec<u8>, Option<Vec<u8>>)>
             if n == field::PAIR_SEPARATOR as u8 {
                 first.pop();
             }
-        };
+        }
     }
 
     match (first.is_empty(), second.is_empty()) {
@@ -111,12 +111,12 @@ mod tests {
         let USN(first, second) = USN::parse_header(double_pair_header).unwrap();
 
         match first {
-            UUID(n) => assert_eq!(&n[..], &(b"device-UUID")[..]),
+            UUID(n) => assert_eq!(n, "device-UUID"),
             _ => panic!("Didnt Match uuid"),
         };
 
         match second.unwrap() {
-            UPnP(n) => assert_eq!(&n[..], &(b"rootdevice")[..]),
+            UPnP(n) => assert_eq!(n, "rootdevice"),
             _ => panic!("Didnt Match upnp"),
         };
     }
@@ -127,7 +127,7 @@ mod tests {
         let USN(first, second) = USN::parse_header(single_pair_header).unwrap();
 
         match first {
-            URN(n) => assert_eq!(&n[..], &(b"device-URN")[..]),
+            URN(n) => assert_eq!(n, "device-URN"),
             _ => panic!("Didnt Match urn"),
         };
 
@@ -140,7 +140,7 @@ mod tests {
         let USN(first, second) = USN::parse_header(trailing_double_colon_header).unwrap();
 
         match first {
-            UPnP(n) => assert_eq!(&n[..], &(b"device-UPnP")[..]),
+            UPnP(n) => assert_eq!(n, "device-UPnP"),
             _ => panic!("Didnt Match upnp"),
         };
 
@@ -154,8 +154,8 @@ mod tests {
 
         match first {
             Unknown(k, v) => {
-                assert_eq!(&k[..], &(b"some-key")[..]);
-                assert_eq!(&v[..], &(b"device-UPnP")[..]);
+                assert_eq!(k, "some-key");
+                assert_eq!(v, "device-UPnP");
             }
             _ => panic!("Didnt Match upnp"),
         };


### PR DESCRIPTION
Breaking changes:
- `FieldMap::{UPnP, UUID, URN, Unknown}` now hold `String` instead of `Vec<u8>`
- `FieldMap::new` now takes `Into<Cow<'a, str>>` instead of a `&[u8]`

Refactored:
- added `FieldMap::parse_bytes` with the same behavior as the old `FieldMap::new`

Additions:
- added constructors on `FieldMap` for each variant:
    * `FieldMap::upnp(..) -> Option<FieldMap::UPnP>`
    * `FieldMap::uuid(..) -> Option<FieldMap::UUID>`
    * `FieldMap::urn(..) -> Option<FieldMap::URN>`
    * `FieldMap::unknown(..) -> Option<FieldMap::Unknown>`
