### PR TITLE
Remove explicit Reflect implementation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use std::convert::From;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
-use std::marker::Reflect;
 
 /// Result that can return a T or an `SSDPError`.
 pub type SSDPResult<T> = Result<T, SSDPError>;
@@ -79,8 +78,6 @@ impl MsgError {
         MsgError { desc: desc }
     }
 }
-
-impl Reflect for MsgError {}
 
 impl Error for MsgError {
     fn description(&self) -> &str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![allow(unused_features)]
-#![feature(lookup_host, reflect_marker)]
-
 //! An asynchronous abstraction for discovering devices and services on a network.
 //!
 //! SSDP stands for Simple Service Discovery Protocol and it is a protocol that uses

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(unused_features)]		
+#![feature(lookup_host)]
+
 //! An asynchronous abstraction for discovering devices and services on a network.
 //!
 //! SSDP stands for Simple Service Discovery Protocol and it is a protocol that uses


### PR DESCRIPTION
`Reflect` is implemented automatically.
`lookup_host` is unused.

All tests pass on nightly and 1.9.0.