### PR TITLE
Foolproof the SSDPReceiver timeout mechanism

### DIFF
--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -28,7 +28,8 @@ impl PacketReceiver {
         if size > pckt_buf.len() {
             Err(Error::new(ErrorKind::Other, "UdpSocket Reported Receive Length Greater Than Buffer"))
         } else {
-            unsafe { pckt_buf.set_len(size) };
+            // `truncate` does not reallocate the vec's backing storage
+            pckt_buf.truncate(size);
 
             Ok((pckt_buf, addr))
         }

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -200,7 +200,9 @@ fn receive_packets<T>(recv: PacketReceiver, kill: Arc<AtomicBool>, send: Sender<
         trace!("Waiting on packet at {}...", recv);
         let (msg_bytes, addr) = match recv.recv_pckt() {
             Ok((bytes, addr)) => (bytes, addr),
-            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => {
+            // Unix returns WouldBlock on timeout while Windows returns TimedOut
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock ||
+                            err.kind() == io::ErrorKind::TimedOut => {
                 // We have waited for at least the desired timeout (or possibly longer)
                 trace!("Receiver at {} timed out", recv);
                 return;


### PR DESCRIPTION
On OS X it is possible to have addresses that cannot receive packets but can send them so set a socket read timeout just to be safe.

I noticed this on tun devices with ipv6 link-local addresses. Previously the `receive_packets` would never time out.