### PR TITLE
Refactor listeners

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssdp"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["GGist <amiller4421@gmail.com>", "Ignacio Corderi <icorderi@msn.com>"]
 description = "An asynchronous abstraction for discovering devices and services on a network."
 documentation = "http://ggist.github.io/ssdp-rs/index.html"

--- a/examples/async_notify.rs
+++ b/examples/async_notify.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use ssdp::FieldMap;
 use ssdp::header::{HeaderMut, NT, NTS, USN};
-use ssdp::message::{NotifyListener, NotifyMessage};
+use ssdp::message::{NotifyListener, NotifyMessage, Listen};
 
 fn main() {
     thread::spawn(|| {

--- a/src/message/listen.rs
+++ b/src/message/listen.rs
@@ -1,0 +1,60 @@
+use std::net::{SocketAddr, IpAddr};
+
+use error::SSDPResult;
+use message;
+use receiver::{SSDPReceiver, FromRawSSDP};
+use net;
+
+pub trait Listen {
+    type Message: FromRawSSDP + Send + 'static;
+
+    /// Listen for messages on all local network interfaces.
+    fn listen() -> SSDPResult<SSDPReceiver<Self::Message>> {
+        Self::listen_on_port(message::UPNP_MULTICAST_PORT)
+    }
+
+    /// Listen for messages on a custom port on all local network interfaces.
+    fn listen_on_port(port: u16) -> SSDPResult<SSDPReceiver<Self::Message>> {
+        let mut ipv4_sock = None;
+        let mut ipv6_sock = None;
+
+        // Generate a list of reused sockets on the standard multicast address.
+        let addrs: Vec<SocketAddr> = try!(message::map_local(|&addr| Ok(Some(addr))));
+
+        for addr in addrs {
+            match addr {
+                SocketAddr::V4(_) => {
+                    let mcast_ip = message::UPNP_MULTICAST_IPV4_ADDR.parse().unwrap();
+
+                    if ipv4_sock.is_none() {
+                        ipv4_sock = Some(try!(net::bind_reuse(("0.0.0.0", port))));
+                    }
+
+                    let ref sock = ipv4_sock.as_ref().unwrap();
+
+                    debug!("Joining ipv4 multicast {} at iface: {}", mcast_ip, addr);
+                    try!(net::join_multicast(&sock, &addr, &mcast_ip));
+                }
+                SocketAddr::V6(_) => {
+                    let mcast_ip = message::UPNP_MULTICAST_IPV6_LINK_LOCAL_ADDR.parse().unwrap();
+
+                    if ipv6_sock.is_none() {
+                        ipv6_sock = Some(try!(net::bind_reuse(("::", port))));
+                    }
+
+                    let ref sock = ipv6_sock.as_ref().unwrap();
+
+                    debug!("Joining ipv6 multicast {} at iface: {}", mcast_ip, addr);
+                    try!(net::join_multicast(&sock, &addr, &IpAddr::V6(mcast_ip)));
+                }
+            }
+        }
+
+        let sockets = vec![ipv4_sock, ipv6_sock]
+            .into_iter()
+            .flat_map(|opt_interface| opt_interface)
+            .collect();
+
+        Ok(try!(SSDPReceiver::new(sockets, None)))
+    }
+}

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -11,9 +11,11 @@ use net::IpVersionMode;
 mod notify;
 mod search;
 mod ssdp;
+mod listen;
 
 pub use message::search::{SearchRequest, SearchResponse, SearchListener};
 pub use message::notify::{NotifyMessage, NotifyListener};
+pub use message::listen::Listen;
 
 #[cfg(not(windows))]
 use ifaces;

--- a/src/message/search.rs
+++ b/src/message/search.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
-use std::net::{ToSocketAddrs, SocketAddr, SocketAddrV6, IpAddr};
+use std::net::{ToSocketAddrs, SocketAddr, SocketAddrV6};
 use std::str::FromStr;
 use std::time::Duration;
 use std::io;
@@ -9,7 +9,7 @@ use hyper::header::{Header, HeaderFormat};
 
 use error::{SSDPResult, MsgError};
 use header::{HeaderRef, HeaderMut, MX};
-use message::{self, MessageType};
+use message::{self, MessageType, Listen};
 use message::ssdp::SSDPMessage;
 use receiver::{SSDPReceiver, FromRawSSDP};
 use net;
@@ -199,56 +199,8 @@ impl Default for SearchResponse {
 /// Search listener that can listen for search messages sent within the network.
 pub struct SearchListener;
 
-impl SearchListener {
-    /// Listen for notify messages on all local network interfaces.
-    pub fn listen() -> SSDPResult<SSDPReceiver<SearchRequest>> {
-        SearchListener::listen_on_port(message::UPNP_MULTICAST_PORT)
-    }
-
-    /// Listen for notify messages on a custom port on all local network interfaces.
-    pub fn listen_on_port(port: u16) -> SSDPResult<SSDPReceiver<SearchRequest>> {
-        let mut ipv4_sock = None;
-        let mut ipv6_sock = None;
-
-        // Generate a list of reused sockets on the standard multicast address.
-        let addrs: Vec<SocketAddr> = try!(message::map_local(|&addr| Ok(Some(addr))));
-
-        for addr in addrs {
-            match addr {
-                SocketAddr::V4(_) => {
-                    let mcast_ip = message::UPNP_MULTICAST_IPV4_ADDR.parse().unwrap();
-
-                    if ipv4_sock.is_none() {
-                        ipv4_sock = Some(try!(net::bind_reuse(("0.0.0.0", port))));
-                    }
-
-                    let ref sock = ipv4_sock.as_ref().unwrap();
-
-                    debug!("Joining ipv4 multicast {} at iface: {}", mcast_ip, addr);
-                    try!(net::join_multicast(&sock, &addr, &mcast_ip));
-                }
-                SocketAddr::V6(_) => {
-                    let mcast_ip = message::UPNP_MULTICAST_IPV6_LINK_LOCAL_ADDR.parse().unwrap();
-
-                    if ipv6_sock.is_none() {
-                        ipv6_sock = Some(try!(net::bind_reuse(("::", port))));
-                    }
-
-                    let ref sock = ipv6_sock.as_ref().unwrap();
-
-                    debug!("Joining ipv6 multicast {} at iface: {}", mcast_ip, addr);
-                    try!(net::join_multicast(&sock, &addr, &IpAddr::V6(mcast_ip)));
-                }
-            }
-        }
-
-        let sockets = vec![ipv4_sock, ipv6_sock]
-            .into_iter()
-            .flat_map(|opt_interface| opt_interface)
-            .collect();
-
-        Ok(try!(SSDPReceiver::new(sockets, None)))
-    }
+impl Listen for SearchListener {
+    type Message = SearchResponse;
 }
 
 impl FromRawSSDP for SearchResponse {


### PR DESCRIPTION
Abstract the **listeners** with a common `Listen` trait

- `NotifyListener` now implements `Listen`
- `SearchListener` now implements `Listen` 

This is a **breaking change** that requires `Listen` to be imported.