### PR TITLE
increase packet size to default mtu length

### DIFF
--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -3,7 +3,7 @@ use std::net::{UdpSocket, SocketAddr};
 use std::fmt;
 
 /// Maximum length for packets received on a `PacketReceiver`.
-pub const MAX_PCKT_LEN: usize = 600;
+pub const MAX_PCKT_LEN: usize = 1500;
 
 /// A `PacketReceiver` that abstracts over a network socket and reads full packets
 /// from the connection. Packets received from this connection are assumed to


### PR DESCRIPTION
This fixes the issue I was hitting in https://github.com/GGist/ssdp-rs/issues/42, where some of the packet was being truncated. I increased the buffer size and logged the error so it is easier to debug in the future.