### PR TITLE
Update interface detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.3"
 net2 = "0.2.23"
 time = "0.1"
 error-chain = "0.10"
+get_if_addrs = "0.5.3"
 
 [dependencies.hyper]
 default-features = false
@@ -22,6 +23,3 @@ version = "0.10.4"
 
 [features]
 unstable = []
-
-[target."cfg(not(windows))".dependencies]
-ifaces = "0.0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(unused_features)]
-#![feature(lookup_host, ip)]
+#![feature(ip)]
 #![recursion_limit = "1024"]
 
 //! An asynchronous abstraction for discovering devices and services on a network.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,7 @@ extern crate hyper;
 #[macro_use]
 extern crate log;
 extern crate time;
-#[cfg(not(windows))]
-extern crate ifaces;
+extern crate get_if_addrs;
 extern crate net2;
 #[macro_use]
 extern crate error_chain;


### PR DESCRIPTION
Use the `get_if_addrs ` crate for interface detection to avoid the deprecated `lookup_host` so we can compile for windows.

There is probably a better solution to get the local connectors but I was trying to avoid major changes.

Fixes #43 